### PR TITLE
fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ map.addControl(geocoderControl);
 If you want to listen to changes and show a popup:
 
 ```javascript
-geocoder.on('change:geocoder', function(evt){
+geocoderControl.on('change:geocoder', function(evt){
     var feature_id = evt.target.get('geocoder');
-    var feature = geocoder.getSource().getFeatureById(feature_id);
+    var feature = geocoderControl.getSource().getFeatureById(feature_id);
     var address = feature.get('address');
     var coord = feature.getGeometry().getCoordinates();
     content.innerHTML = '<p>'+address+'</p>';

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Load the CSS and Javascript:
 Add the control:
 
 ```javascript
-var geocoder = new geocoder.Nominatim();
-map.addControl(geocoder);
+var geocoderControl = new geocoder.Nominatim();
+map.addControl(geocoderControl);
 ```
 
 If you want to listen to changes and show a popup:


### PR DESCRIPTION
the code example in readme will be undefined in function scope.
e.g. 
```javascript
function try() { 
    var geocoder = new geocoder.Nominatim(); 
    //error: property not found
}
```
err: property not found, because the variable `geocoder` in `new geocoder.Nominatim()` is already the just created from local scope, not the variable from global window scope.



another possible fix: 
```javascript
var geocoder = new window.geocoder.Nominatim();
```