### PR TITLE
Add constructor property `preventDefault`

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -51,5 +51,6 @@ export const defaultOptions = {
   lang: 'en-US',
   limit: 5,
   keepOpen: false,
+  preventDefault: false,
   debug: false
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -70,6 +70,24 @@ export default {
     
     return window.performance.now();
   },
+  flyTo(map, coord, duration, resolution) {
+    resolution = resolution || 2.388657133911758;
+    duration = duration || 500;
+
+    const view = map.getView();
+    const pan = ol.animation.pan({
+      duration: duration,
+      source: view.getCenter()
+    });
+    const zoom = ol.animation.zoom({
+      duration: duration,
+      resolution: view.getResolution()
+    });
+    
+    map.beforeRender(pan, zoom);
+    view.setCenter(coord);
+    view.setResolution(resolution);
+  },
   randomId(prefix) {
     const id = this.now().toString(36);
     return prefix ? prefix + id : id;
@@ -247,7 +265,7 @@ export default {
   * obj2's if non existent in obj1
   * @returns obj3 a new object based on obj1 and obj2
   */
-  mergeOptions: function(obj1, obj2){
+  mergeOptions(obj1, obj2) {
     let obj3 = {};
     for (let attr1 in obj1) { obj3[attr1] = obj1[attr1]; }
     for (let attr2 in obj2) { obj3[attr2] = obj2[attr2]; }


### PR DESCRIPTION
With this new constructor property you can prevent Geocoder panning (**and** creating `ol.Feature`) when an address is chosen. Default is `false`.

Another important change is that Geocoder `addresschosen` listener now has the **address** in a separate object. That is:

```javascript
geocoder.on('addresschosen', function(evt) {
  var address = evt.address;

  console.info(address.formatted); // HTML string
  console.info(address.details); // details object
  console.info(address.original); // object with the same provider response
});
```

Also addresses #47 
