### PR TITLE
Added a check to prevent the same parameters being queried repeatedly

### DIFF
--- a/src/js/nominatim.js
+++ b/src/js/nominatim.js
@@ -117,10 +117,8 @@ export class Nominatim {
           countrycodes: options.countrycodes,
           limit: options.limit
         });
-    if(this.prev_params == provider.params){
-      return false;
-    }
-    this.prev_params = provider.params;
+    if (this.last_query === q) return;
+    this.last_query = q;
     this.clearResults();
     utils.addClass(input, vars.namespace + vars.loading_class);
     

--- a/src/js/nominatim.js
+++ b/src/js/nominatim.js
@@ -117,7 +117,10 @@ export class Nominatim {
           countrycodes: options.countrycodes,
           limit: options.limit
         });
-
+    if(this.prev_params == provider.params){
+      return false;
+    }
+    this.prev_params = provider.params;
     this.clearResults();
     utils.addClass(input, vars.namespace + vars.loading_class);
     


### PR DESCRIPTION
This addition makes sure that the query functionallity is only run when there is a different set of parameters. It prevents users from spamming the ajax calls