### PR TITLE
Fix enter keypress triggering form submit

### DIFF
--- a/src/js/nominatim.js
+++ b/src/js/nominatim.js
@@ -85,7 +85,7 @@ export class Nominatim {
         }, 200);
       }
     };
-    this.els.input.addEventListener('keyup', query, false);
+    this.els.input.addEventListener('keypress', query, false);
     this.els.input.addEventListener('input', handleValue, false);
     this.els.reset.addEventListener('click', reset, false);
     if (this.options.targetType === C.targetType.GLASS) {


### PR DESCRIPTION
The geocoder search field is listening for `keyup` events to trigger search when Enter is pressed. When using the geocoder inside a form, an Enter keypress in the geocoder search field triggers  submit.

I'm proposing to change the listener from `keyup` to `keypress`. This will allow the `preventDefault()` call in the `query` event listener to correctly stop the event from bubbling.